### PR TITLE
Fix color passed in options did not set the progress bar color

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -49,7 +49,7 @@ export default class ProgressBar {
       padding: 0,
       border: "none",
       borderRadius: 0,
-      backgroundColor: "currentColor",
+      backgroundColor: config.color,
       zIndex: 10000,
       height:
         typeof config.size === "number" ? config.size + "px" : config.size,


### PR DESCRIPTION
# Goal of this PR

Fix the fact that we could not set the color for the progress bar.

# What this PR does

Update one file: `index.ts` by setting `initialStyle.backgroundColor` to `config.color` instead of `"currentColor"`.

## Context

This PR follows #17.

Thanks again to @jviide! 🎉